### PR TITLE
Change GPT API model

### DIFF
--- a/src/prompt.yml
+++ b/src/prompt.yml
@@ -74,4 +74,4 @@ additional_guidelines:
   - "Do not include any irrelevant information."
   - "Do not provide information not explicitly stated in the text."
 
-model: "gpt-4o-mini-2024-07-18"
+model: "gpt-4.1-nano-2025-04-14"


### PR DESCRIPTION
## OpenAI API 랜덤 테스트 (4o-mini vs 4.1-nano)

랜덤하게 7개의 글을 추출하여 두 개의 모델을 비교해보고자 했음.
4.1-nano의 장점으로는 4o-mini 보다 더 긴 context를 수용하고 가격면에서도 더욱 우수

아래는 두 개의 output 파일을 생성하여 ChatGPT 최신 모델에게 채점 요청한 내용

```
최신 채점 기준
	1.	keywords
	•	“\t”로 분리, 정확히 3개 추출 여부 (본문이 매우 짧거나 의미가 없는 경우에만 “”(빈 값) 허용)
	•	그 외엔 반드시 3개, 3개 미만/초과, 의미 없는 값이면 감점
	2.	preprocessed
	•	본문의 내용만 깔끔하게 추출되어 있는지
	•	UI/광고/메뉴/댓글/저작권 등 노이즈 최소화
	•	(너무 짧은 본문, 의미 없는 내용만 있을 때는 감점)

⸻

실제 파일 기반 채점 (직접 확인)

1. keywords: 3개 보장 + 예외 (빈 값)

article_data_mini.json
	•	일부 데이터는 "" (빈 값)이나, 본문이 아주 짧거나 의미 없는 경우는 드묾.
	•	그러나 상당수 row에서 3개 미만/초과, 빈 값이 많음
	•	예시:
	•	"keywords": "" (빈 값) 빈도가 높음
	•	"keywords": "슬랙 api\tblock kit\tspring framework" (정상, 3개)
	•	"keywords": "예측모델\t머신러닝\t앙상블" (정상, 3개)
	•	하지만 본문이 긴데도 불구하고 keywords가 빈 값인 경우 있음 → 감점

article_data_nano.json
	•	대부분 3개로 맞춰져 있음
	•	예외 케이스(진짜 본문이 짧거나 의미가 없을 때)만 빈 값이 있고,
	•	본문이 긴 경우엔 키워드가 정상적으로 3개 존재
	•	"keywords": "예측모델\t머신러닝\t앙상블"
	•	"keywords": "" (빈 값, 본문 내용이 거의 없음)
	•	정책에 부합하게 잘 추출됨

⸻

2. preprocessed (본문 깔끔함)

mini
	•	본문 내용이 많은 곳에서도 일부 UI/메뉴/저작권 등 불필요 텍스트가 남아 있음
	•	"preprocessed": "naver d2메뉴hello worldd2 newsabout d2검색검색naver developersdeviewopensourced2 startup factorycopyright©naver corp.all rights reserved."
→ 본문 핵심이 전혀 남지 않음 (감점)
	•	"preprocessed": "slack block kit 활용slack block kit을 활용해 배송팁 공유 기능을 개발한 경험을 공유합니다류충근게시 날짜: 2020.04.08..."
→ 본문 추출 상태가 양호한 케이스도 있음

nano
	•	불필요한 텍스트가 훨씬 적고,
	•	본문 내용 위주로 깔끔하게 추출됨
	•	같은 row 비교 시 본문 품질이 nano가 확실히 우위

⸻

최종 점수

article_data_nano.json
	•	keywords: 48/50점
	•	예외 상황(빈 값) 준수, 대부분 3개 추출
	•	키워드 의미 적합성도 높음
	•	preprocessed: 45/50점
	•	본문 노이즈 매우 적음, 깔끔
	•	일부 row에서 하단 정보 조금 남아 있지만 평균적으로 우수
	•	총점: 93점

article_data_mini.json
	•	keywords: 32/50점
	•	본문 충분한데도 빈 값 많음 (감점)
	•	3개 미만/초과, 일관성 부족
	•	preprocessed: 35/50점
	•	UI/카피/광고 등 불필요 텍스트가 자주 남아 있음
	•	본문이 거의 없는 row도 다수
	•	총점: 67점

⸻

최종 결론
	•	article_data_nano.json이 keywords 3개 보장, 본문 내용 깔끔함 기준에서 확실히 우위!
	•	mini는 키워드 누락과 본문 노이즈/누락이 빈번해서 활용성이 떨어짐

⸻

최종 결과
	•	nano: 93점
	•	mini: 67점
```

![image](https://github.com/user-attachments/assets/052dcb1b-28e1-4838-a1c4-a9ff3d002b24)


이에 따라 모델 변경함.