### PR TITLE
LLM 호출 우선순위 변경

### DIFF
--- a/src/llm_pipeline/model.py
+++ b/src/llm_pipeline/model.py
@@ -9,7 +9,7 @@ from .schemas import TopicClassification
 
 class LangChainModel:
     def __init__(self):
-        AWS_LLM_MODEL = "apac.amazon.nova-micro-v1:0"
+        AWS_LLM_MODEL = "apac.amazon.nova-lite-v1:0"
         OPENAI_LLM_MODEL = "gpt-4.1-nano-2025-04-14"
 
         # Load prompt config
@@ -19,22 +19,21 @@ class LangChainModel:
         self.prompt_generator = PromptGenerator(self.prompt_data)
 
         # LLM clients
-        self.model = ChatBedrockConverse(
+        self.model = ChatOpenAI(
+                model_name=OPENAI_LLM_MODEL,
+            temperature=0
+        )
+
+        self.back_up = ChatBedrockConverse(
             model_id=AWS_LLM_MODEL,
             region_name="ap-northeast-2",
             temperature=0,
-            top_p=0.95,
-            max_tokens=128_000
-        )
-        self.back_up = ChatOpenAI(
-            model_name=OPENAI_LLM_MODEL,
-            temperature=0
         )
 
     def _safe_parser(self):
         def _inner(msg):
             content = msg.content if hasattr(msg, "content") else msg
-            print("[DEBUG] Bedrock raw output:\n", content)
+            # print("[DEBUG] LLM raw output:\n", content)
             return self._try_parse(content)
         return RunnableLambda(_inner)
 
@@ -44,7 +43,7 @@ class LangChainModel:
             if not match:
                 raise ValueError("No JSON object found in text.")
             json_str = match.group()
-            print("[DEBUG] Extracted JSON string:\n", json_str)
+            # print("[DEBUG] Extracted JSON string:\n", json_str)
             return json.loads(json_str)
         except json.JSONDecodeError as je:
             print(f"[extract_json] JSON decode error: {je}")
@@ -73,8 +72,8 @@ class LangChainModel:
             print("=" * 50)
 
         chains = [
-            ("AWS Bedrock", self.prompt_generator.prompt | self.model | self._safe_parser()),
-            ("OpenAI", self.prompt_generator.retry | self.back_up | self._safe_parser()),
+            ("OpenAI", self.prompt_generator.prompt | self.model | self._safe_parser()),
+            ("AWS Bedrock", self.prompt_generator.retry | self.back_up | self._safe_parser()),
         ]
 
         for name, chain in chains:

--- a/src/llm_pipeline/model.py
+++ b/src/llm_pipeline/model.py
@@ -9,7 +9,7 @@ from .schemas import TopicClassification
 
 class LangChainModel:
     def __init__(self):
-        AWS_LLM_MODEL = "apac.amazon.nova-lite-v1:0"
+        AWS_LLM_MODEL = "apac.amazon.nova-micro-v1:0"
         OPENAI_LLM_MODEL = "gpt-4.1-nano-2025-04-14"
 
         # Load prompt config

--- a/src/main.py
+++ b/src/main.py
@@ -43,7 +43,11 @@ async def process_article(data):
 
         print(f"[PREDICT] Article ID: {article_id}")
         query = f"Title : {title}, Description : {desc_processed}, Body Content : {preprocessed}"
-        predict = await asyncio.to_thread(MODEL.predict, query)
+        predict = await asyncio.to_thread(
+            MODEL.predict, # predict 함수 비동기
+            query, # predict에 들어갈 Query 문
+            False # verbose option : show prompt
+        )
         content = predict.content
 
         values = (


### PR DESCRIPTION
## Problem : Bedrock의 max_output_token 부족

<img width="1153" height="471" alt="image" src="https://github.com/user-attachments/assets/7d3bdda3-c46c-4997-ad7f-5ae28cb9f83d" />


기술 블로그 특성 상 길이가 굉장히 긴데 Bedrock에 내장되어 있는 aws nova 모델의 경우 `max_output_token` 수가 **10K** 로 고정되어 있음. 이는 **30K** 인 OpenAI API 와 비교했을 때 너무 작은 값이기에 우선순위를 낮추었음 (즉 AWS Bedrock 모델이 Fallback Logic에 활용).

---

### 추후 이슈 해결 방법

* Qwen 계열 모델로 변경
* 다른 모델을 AWS 상에서 Deploy 하는 것을 고려 중