### PR TITLE
feat: harvest_post GPU 자체 호스팅 + vLLM 단일화 + webhook CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install validation deps
+        run: pip install pyyaml
+
       - name: Syntax check Python sources
         run: |
           python -m compileall -q src scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,7 @@ jobs:
 
       - name: Validate docker-compose.gpu.yml
         run: |
+          # env_file points at .env which is gitignored — provide an empty
+          # stub so `docker compose config` succeeds on the syntax check.
+          touch .env
           docker compose -f docker-compose.gpu.yml config --quiet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [prod, dev]
+  pull_request:
+    branches: [prod]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Syntax check Python sources
+        run: |
+          python -m compileall -q src scripts
+
+      - name: Validate prompt.yml
+        run: |
+          python -c "import yaml; yaml.safe_load(open('src/prompt.yml'))"
+
+      - name: Validate docker-compose.gpu.yml
+        run: |
+          docker compose -f docker-compose.gpu.yml config --quiet

--- a/.github/workflows/deploy-homeserver.yml
+++ b/.github/workflows/deploy-homeserver.yml
@@ -1,0 +1,35 @@
+name: Deploy Harvest Post to Home Server
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: ["prod"]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Check deploy secrets
+        id: deploy_guard
+        env:
+          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          DEPLOY_WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DEPLOY_TOKEN" ] || [ -z "$DEPLOY_WEBHOOK_URL" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy via webhook (WoL + SSH + git pull + rebuild on GPU)
+        if: steps.deploy_guard.outputs.enabled == 'true'
+        run: |
+          RESPONSE=$(curl -sf --max-time 300 -X POST \
+            "${{ secrets.DEPLOY_WEBHOOK_URL }}/deploy?service=harvest-post" \
+            -H "Authorization: Bearer ${{ secrets.DEPLOY_TOKEN }}")
+          echo "$RESPONSE"
+          echo "$RESPONSE" | grep -q '"ok":true' || exit 1

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+COPY requirements.txt .
+RUN uv venv /app/.venv && \
+    . /app/.venv/bin/activate && \
+    uv pip install -r requirements.txt
+
+COPY src/ /app/src/
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app/src
+CMD ["python3", "-m", "main", "--continuous"]

--- a/chat_template_nothink.jinja
+++ b/chat_template_nothink.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is not defined or enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,98 @@
+# Self-hosted GPU stack for harvest_post.
+#
+# Layout:
+#   vllm-chat  — Qwen3.5-9B-AWQ, chat model, /v1/chat/completions on :8000
+#   vllm-embed — Qwen3-Embedding-0.6B, embedding model, /v1/embeddings on :8001
+#   harvest-post — Python batch job, talks to both vLLM instances via the
+#                  bridge network using DNS names (vllm-chat / vllm-embed).
+#
+# Both vLLM instances share the one local GPU. Memory utilization is split:
+#   chat:  0.55 → ~9GB on a 16GB 5060 Ti (AWQ-quantised 9B)
+#   embed: 0.15 → ~2GB (0.6B model)
+# Remaining ~5GB is headroom for CUDA kernels + overlap.
+#
+# HuggingFace cache is mounted from the host so models persist across
+# container restarts and survive `docker compose down -v`.
+
+services:
+  vllm-chat:
+    image: vllm/vllm-openai:latest
+    container_name: gpu-vllm-chat
+    runtime: nvidia
+    ipc: host
+    command: >
+      --model QuantTrio/Qwen3.5-9B-AWQ
+      --served-model-name qwen3.5:9b
+      --max-model-len 8192
+      --gpu-memory-utilization 0.55
+      --quantization awq_marlin
+      --enforce-eager
+      --chat-template /app/chat_template_nothink.jinja
+      --port 8000
+      --host 0.0.0.0
+    volumes:
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
+      - ./chat_template_nothink.jinja:/app/chat_template_nothink.jinja:ro
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 40
+      start_period: 90s
+    restart: unless-stopped
+    networks:
+      - gpu-network
+
+  vllm-embed:
+    image: vllm/vllm-openai:latest
+    container_name: gpu-vllm-embed
+    runtime: nvidia
+    ipc: host
+    command: >
+      --model Qwen/Qwen3-Embedding-0.6B
+      --served-model-name qwen3-embedding:0.6b
+      --task embed
+      --max-model-len 2048
+      --gpu-memory-utilization 0.15
+      --enforce-eager
+      --port 8001
+      --host 0.0.0.0
+    volumes:
+      - ${HOME}/.cache/huggingface:/root/.cache/huggingface
+    ports:
+      - "8001:8001"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8001/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+    restart: unless-stopped
+    networks:
+      - gpu-network
+
+  harvest-post:
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+    image: harvest-post:local
+    container_name: gpu-harvest-post
+    env_file:
+      - .env
+    environment:
+      - VLLM_BASE_URL=http://vllm-chat:8000/v1
+      - VLLM_EMBED_BASE_URL=http://vllm-embed:8001/v1
+    depends_on:
+      vllm-chat:
+        condition: service_healthy
+      vllm-embed:
+        condition: service_healthy
+    networks:
+      - gpu-network
+    restart: "no"
+
+networks:
+  gpu-network:
+    driver: bridge

--- a/harvest-post.service
+++ b/harvest-post.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Harvest Post - Blog Article Processing via Local LLM
+After=network-online.target docker.service
+Wants=network-online.target docker.service
+
+[Service]
+Type=oneshot
+User=siroo
+WorkingDirectory=/home/siroo/harvest_post
+ExecStart=/home/siroo/harvest_post/run.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=3600
+
+# DB credentials — used by scripts/sync_bite_to_dev.py and by the
+# harvest-post container (via .env merging). vLLM endpoint URLs are NOT
+# set here: they belong to the container network and are configured in
+# docker-compose.gpu.yml's `environment:` section.
+Environment=ARTICLE_TABLE=article
+Environment=DB_HOST=192.168.219.104
+Environment=DB_PORT=3306
+Environment=DB_USER=bite-dev
+Environment=DB_PASSWORD=qkdlxm!
+Environment=DB_NAME=bite
+Environment=QDRANT_HOST=http://192.168.219.104
+Environment=QDRANT_PROD_PORT=6333
+Environment=QDRANT_DEV_PORT=6335
+Environment=LIMIT=50
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,24 @@
 # 필수 유틸
-python-dotenv==1.0.1
+python-dotenv>=1.0.0
 
 # 데이터 처리
-numpy==1.24.4
-pandas==2.1.4
-sqlalchemy==2.0.25
-pymysql==1.1.0
+numpy>=1.26.0,<2
+pandas>=2.1.0
+sqlalchemy>=2.0.0
+pymysql>=1.1.1
 
 # 웹 크롤링
-beautifulsoup4==4.12.3
-lxml==4.9.3
-trafilatura==1.6.1
+beautifulsoup4>=4.12.0
+lxml>=4.9.0
+trafilatura>=1.6.0
 
-# LLM - 버전 호환성 고정
-langchain==0.3.14
-langchain-core==0.3.29
-langchain-text-splitters==0.3.4
-langchain-openai==0.2.14
-langchain-aws==0.2.10
-pydantic==2.10.4
+# LLM — both chat and embedding served via vLLM's OpenAI-compatible API
+langchain>=0.3.0
+langchain-core>=0.3.81
+langchain-text-splitters>=0.3.9
+langchain-openai>=0.2.0
+pydantic>=2.0.0
+requests>=2.31.0
 
 # Vector DB
-qdrant-client==1.16.2
-
-# AWS
-boto3==1.35.86
+qdrant-client>=1.16.0

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# harvest_post runner invoked on GPU machine after WoL wake.
+#
+# Responsibilities:
+#   1. pull latest code from git (source of truth = origin/prod)
+#   2. bring up docker-compose stack: vllm-chat + vllm-embed + harvest-post
+#   3. wait for harvest-post container to finish draining article_queue
+#   4. sync bite → bite_dev
+#   5. tear down and power off
+#
+# All stdout/stderr goes to systemd journal (no /var/log files). View via:
+#   journalctl -u harvest-post.service -f
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MAC_IP="192.168.219.104"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
+
+log "=== Harvest Post Started ==="
+
+# --- 0. Sanity: can we reach the Mac? ---
+if ! ping -c 1 -W 3 "$MAC_IP" > /dev/null 2>&1; then
+    log "ERROR: Cannot reach Mac ($MAC_IP). Aborting."
+    exit 1
+fi
+
+cd "$SCRIPT_DIR"
+
+# --- 1. Pull latest code ---
+# Deploy webhook may have already done this, but re-running is idempotent
+# and covers the cron-triggered wake path where no webhook ran.
+log "git pull origin prod"
+git pull --rebase origin prod || log "WARN: git pull failed, continuing with existing checkout"
+
+# --- 2. Force DB_NAME to production regardless of stored .env value ---
+sed -i 's/^DB_NAME=.*/DB_NAME=bite/' .env
+
+# --- 3. Bring up the stack (vllm-chat + vllm-embed + harvest-post) ---
+# docker-compose.gpu.yml's harvest-post has depends_on:{vllm-chat,vllm-embed}
+# with service_healthy conditions, so `up -d` blocks until vLLM instances
+# report healthy before starting harvest-post.
+log "docker compose up -d --build"
+docker compose -f docker-compose.gpu.yml up -d --build
+
+# --- 4. Wait for harvest-post container to exit ---
+# harvest-post CMD is `python3 -m main --continuous`, which exits after the
+# queue is empty. docker compose wait blocks until the container stops and
+# returns its exit code.
+log "waiting for harvest-post to finish"
+set +e
+docker compose -f docker-compose.gpu.yml wait harvest-post
+HARVEST_EXIT=$?
+set -e
+log "harvest-post exited with code $HARVEST_EXIT"
+
+# --- 5. Sync bite → bite_dev (best-effort, do not fail overall run) ---
+if [ -f "$SCRIPT_DIR/scripts/sync_bite_to_dev.py" ]; then
+    log "syncing bite → bite_dev"
+    python3 "$SCRIPT_DIR/scripts/sync_bite_to_dev.py" || log "WARN: dev sync failed"
+else
+    log "sync script not found, skipping dev sync"
+fi
+
+# --- 6. Tear down + power off ---
+log "docker compose down"
+docker compose -f docker-compose.gpu.yml down
+
+log "=== Done. Shutting down. ==="
+sudo /usr/sbin/shutdown -h now

--- a/scripts/sync_bite_to_dev.py
+++ b/scripts/sync_bite_to_dev.py
@@ -1,0 +1,158 @@
+"""
+Mirror production bite DB + Qdrant collection to the dev environment.
+
+Invoked from run.sh after a successful harvest cycle. Safe to run multiple
+times — MySQL upserts use ON DUPLICATE KEY UPDATE; Qdrant upserts overwrite
+by id.
+
+Credentials / hosts are read from environment variables (NO hardcoded
+passwords). The GPU harvest-post.service provides DB_HOST / DB_USER /
+DB_PASSWORD via Environment= directives.
+"""
+
+import json
+import os
+import ssl
+import sys
+from urllib.request import Request, urlopen
+
+import pymysql
+
+
+def sync_mysql(host: str, user: str, password: str) -> None:
+    ssl_ctx = ssl.create_default_context()
+    ssl_ctx.check_hostname = False
+    ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    conn = pymysql.connect(host=host, port=3306, user=user, password=password, ssl=ssl_ctx)
+    try:
+        cur = conn.cursor()
+
+        # article table — upsert all rows
+        cur.execute("""
+            INSERT INTO bite_dev.article
+            SELECT * FROM bite.article
+            ON DUPLICATE KEY UPDATE
+                keywords=VALUES(keywords), category_id=VALUES(category_id),
+                content=VALUES(content), content_length=VALUES(content_length),
+                lang=VALUES(lang), updated_at=VALUES(updated_at),
+                description=VALUES(description), thumbnail=VALUES(thumbnail)
+        """)
+
+        # article_queue — snapshot replace
+        cur.execute("DELETE FROM bite_dev.article_queue")
+        cur.execute("INSERT INTO bite_dev.article_queue SELECT * FROM bite.article_queue")
+
+        # article_rejected — snapshot replace so dev mirrors prod rejections
+        cur.execute("DELETE FROM bite_dev.article_rejected")
+        cur.execute("INSERT INTO bite_dev.article_rejected SELECT * FROM bite.article_rejected")
+
+        # blog favicon — join update
+        cur.execute("""
+            UPDATE bite_dev.blog b
+            JOIN bite.blog s ON b.blog_id = s.blog_id
+            SET b.favicon = s.favicon
+        """)
+
+        # llm_config_metadata — upsert
+        cur.execute("""
+            INSERT INTO bite_dev.llm_config_metadata (llm_model, embedding_model, embedding_size, chunk_size)
+            SELECT llm_model, embedding_model, embedding_size, chunk_size FROM bite.llm_config_metadata
+            ON DUPLICATE KEY UPDATE
+                llm_model=VALUES(llm_model), embedding_model=VALUES(embedding_model),
+                embedding_size=VALUES(embedding_size), chunk_size=VALUES(chunk_size)
+        """)
+
+        conn.commit()
+    finally:
+        conn.close()
+    print("[SYNC] MySQL bite → bite_dev done")
+
+
+def sync_qdrant(host: str, prod_port: int, dev_port: int, collection: str) -> None:
+    prod = f"http://{host}:{prod_port}"
+    dev = f"http://{host}:{dev_port}"
+
+    # ensure dev collection exists — if not, clone config from prod
+    try:
+        config = json.loads(urlopen(f"{prod}/collections/{collection}").read())["result"]["config"]["params"]
+        try:
+            urlopen(f"{dev}/collections/{collection}")
+        except Exception:
+            req = Request(
+                f"{dev}/collections/{collection}",
+                method="PUT",
+                data=json.dumps({"vectors": config["vectors"]}).encode(),
+                headers={"Content-Type": "application/json"},
+            )
+            urlopen(req)
+    except Exception as e:
+        print(f"[WARN] Qdrant collection setup: {e}")
+        return
+
+    # scroll + batch upsert
+    offset = None
+    total = 0
+    while True:
+        body = {"limit": 100, "with_payload": True, "with_vector": True}
+        if offset:
+            body["offset"] = offset
+
+        req = Request(
+            f"{prod}/collections/{collection}/points/scroll",
+            method="POST",
+            data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        resp = json.loads(urlopen(req).read())
+        points = resp["result"]["points"]
+        if not points:
+            break
+
+        upsert = [
+            {"id": p["id"], "vector": p["vector"], "payload": p.get("payload", {})}
+            for p in points
+        ]
+        req = Request(
+            f"{dev}/collections/{collection}/points",
+            method="PUT",
+            data=json.dumps({"points": upsert}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        urlopen(req)
+
+        total += len(points)
+        offset = resp["result"].get("next_page_offset")
+        if offset is None:
+            break
+
+    print(f"[SYNC] Qdrant prod → dev done ({total} points)")
+
+
+def main() -> int:
+    host = os.getenv("DB_HOST") or "192.168.219.104"
+    user = os.getenv("DB_USER")
+    password = os.getenv("DB_PASSWORD")
+    if not user or not password:
+        print("[ERROR] DB_USER / DB_PASSWORD env vars are required", file=sys.stderr)
+        return 1
+
+    try:
+        sync_mysql(host, user, password)
+    except Exception as e:
+        print(f"[ERROR] MySQL sync failed: {e}", file=sys.stderr)
+        return 2
+
+    qdrant_prod_port = int(os.getenv("QDRANT_PROD_PORT", "6333"))
+    qdrant_dev_port = int(os.getenv("QDRANT_DEV_PORT", "6335"))
+    try:
+        sync_qdrant(host, qdrant_prod_port, qdrant_dev_port, "bite-vectordb")
+    except Exception as e:
+        print(f"[ERROR] Qdrant sync failed: {e}", file=sys.stderr)
+        return 3
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/config.py
+++ b/src/config.py
@@ -17,8 +17,10 @@ QUALITY_REJECT_THRESHOLD = int(os.getenv('QUALITY_REJECT_THRESHOLD', 3))
 
 
 # ---------- Inference Server Configuration ----------
-OLLAMA_BASE_URL = os.getenv('OLLAMA_BASE_URL', 'http://localhost:11434')
-VLLM_BASE_URL = os.getenv('VLLM_BASE_URL', 'http://localhost:8000/v1')
+# Two separate vLLM instances: one for chat (LLM classifier), one for embedding.
+# Both speak the OpenAI-compatible /v1 API.
+VLLM_BASE_URL = os.getenv('VLLM_BASE_URL', 'http://vllm-chat:8000/v1')
+VLLM_EMBED_BASE_URL = os.getenv('VLLM_EMBED_BASE_URL', 'http://vllm-embed:8001/v1')
 
 
 # ---------- LLM Configuration (Single Source of Truth) ----------

--- a/src/db_conn.py
+++ b/src/db_conn.py
@@ -27,11 +27,20 @@ class Connection:
     def connect_to_engine(self, host, user, password, database, port):
         """ SQLAlchemy 엔진 생성 """
         DATABASE_URL = f"mysql+pymysql://{user}:{password}@{host}:{port}/{database}"
+        connect_args = {}
+        # 외부 접속 시 SSL 활성화 (require_secure_transport=ON 대응)
+        if host not in ('localhost', '127.0.0.1'):
+            import ssl
+            ssl_ctx = ssl.create_default_context()
+            ssl_ctx.check_hostname = False
+            ssl_ctx.verify_mode = ssl.CERT_NONE
+            connect_args['ssl'] = ssl_ctx
         return create_engine(
             DATABASE_URL,
             pool_size=10,
             max_overflow=20,
-            pool_pre_ping=True
+            pool_pre_ping=True,
+            connect_args=connect_args
         )
 
     def _connect_to_rds(self):

--- a/src/embedder.py
+++ b/src/embedder.py
@@ -1,25 +1,29 @@
 import os
-import json
-import boto3
 import asyncio
+import requests
 from typing import List
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from numpy.linalg import norm
+from config import VLLM_EMBED_BASE_URL, EMBEDDING_CONFIG
+
 
 class TextEmbeddings:
-    accept = "application/json"
-    content_type = "application/json"
+    """Embedding generator backed by a vLLM instance running an embedding
+    model (e.g. Qwen3-Embedding-0.6B) via the OpenAI-compatible
+    /v1/embeddings endpoint. Matryoshka-style dimension truncation and
+    optional L2 normalization are applied client-side so the same embeddings
+    pipeline works regardless of the underlying vLLM model."""
+
     separator = "\n\n###\n\n"  # 안정적인 구조화 구분자
 
     def __init__(
         self,
-        model_id: str = "amazon.titan-embed-text-v2:0",
-        region: str = "ap-northeast-2",
+        model: str = None,
         chunk_size: int = None,
         chunk_overlap: int = 200
     ):
-        self.bedrock = boto3.client("bedrock-runtime", region_name=region)
-        self.model_id = model_id
+        self.base_url = VLLM_EMBED_BASE_URL.rstrip("/")
+        self.model = model or EMBEDDING_CONFIG.model
         self.chunk_size = chunk_size or int(os.getenv("CHUNK_SIZE", 5000))
         self.chunk_overlap = chunk_overlap
         self.chunker = RecursiveCharacterTextSplitter(
@@ -29,22 +33,32 @@ class TextEmbeddings:
         )
 
     def _embed_once(self, text: str, dimensions: int, normalize: bool) -> List[float]:
-        body = json.dumps({
-            "inputText": text,
-            "dimensions": dimensions,
-            "normalize": normalize
-        })
         try:
-            response = self.bedrock.invoke_model(
-                body=body,
-                modelId=self.model_id,
-                accept=self.accept,
-                contentType=self.content_type
+            response = requests.post(
+                f"{self.base_url}/embeddings",
+                json={
+                    "model": self.model,
+                    "input": text,
+                },
+                headers={"Authorization": "Bearer not-needed"},
+                timeout=300,
             )
-            resp_body = json.loads(response["body"].read())
-            return resp_body["embedding"]
+            response.raise_for_status()
+            payload = response.json()
+            embeddings = payload["data"][0]["embedding"]
+
+            # 차원 truncate (Matryoshka 지원 모델)
+            if len(embeddings) > dimensions:
+                embeddings = embeddings[:dimensions]
+
+            if normalize:
+                l2 = norm(embeddings)
+                if l2 > 0:
+                    embeddings = [v / l2 for v in embeddings]
+
+            return embeddings
         except Exception as e:
-            print(f"[TitanEmbedding] Failed to embed: {e}")
+            print(f"[vLLMEmbedding] Failed to embed: {e}")
             raise
 
     async def embed_text(self, text: str, dimensions: int, normalize: bool = True) -> List[float]:
@@ -69,13 +83,15 @@ class TextEmbeddings:
 
         return avg
 
-    async def __call__(self,
-                       title: str,
-                       description: str,
-                       keywords: str,
-                       content: str,
-                       dimensions: int,
-                       normalize: bool = True) -> List[float]:
+    async def __call__(
+        self,
+        title: str,
+        description: str,
+        keywords: str,
+        content: str,
+        dimensions: int,
+        normalize: bool = True
+    ) -> List[float]:
 
         merged = (
             f"Title: {title}{self.separator}"

--- a/src/llm_pipeline/model.py
+++ b/src/llm_pipeline/model.py
@@ -7,7 +7,7 @@ import os
 
 # config 모듈 경로 추가
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from config import LLM_CONFIG
+from config import LLM_CONFIG, VLLM_BASE_URL
 
 from langchain_openai import ChatOpenAI
 from langchain_core.runnables import RunnableLambda
@@ -27,9 +27,11 @@ class LangChainModel:
 
         self.prompt_generator = PromptGenerator(self.prompt_data)
 
-        # 설정을 config에서 가져옴 (Single Source of Truth)
+        # vLLM OpenAI-compatible API 사용
         self.model = ChatOpenAI(
-            model_name=LLM_CONFIG.model,
+            model=LLM_CONFIG.model,
+            base_url=VLLM_BASE_URL,
+            api_key="not-needed",
             temperature=LLM_CONFIG.temperature,
         )
 
@@ -44,10 +46,8 @@ class LangChainModel:
         schema_keys = {'$defs', 'properties', 'enum', 'title', 'type', 'required', '$ref'}
         if not isinstance(obj, dict):
             return False
-        # 스키마 키가 있고 실제 데이터 키가 없으면 스키마
         has_schema_keys = bool(set(obj.keys()) & schema_keys)
         has_data_keys = bool({'content', 'focusing', 'keywords', 'lang'} & set(obj.keys()))
-        # 중첩된 스키마 확인 (Category 등)
         for v in obj.values():
             if isinstance(v, dict) and ('enum' in v or 'type' in v or '$ref' in v):
                 return True
@@ -55,14 +55,12 @@ class LangChainModel:
 
     def extract_json(self, text: str) -> dict:
         """텍스트에서 실제 데이터 JSON 추출 (스키마 정의 제외)"""
-        # greedy 매칭으로 가장 큰 JSON 찾기
         match = re.search(r'\{.*\}', text, re.DOTALL)
         if not match:
             raise ValueError("No JSON object found in text.")
 
         json_str = match.group()
 
-        # 여러 JSON이 연결된 경우 분리 시도
         try:
             parsed = json.loads(json_str)
             if not self._is_schema(parsed):
@@ -70,8 +68,6 @@ class LangChainModel:
         except json.JSONDecodeError:
             pass
 
-        # 스키마가 포함된 경우, 텍스트에서 실제 데이터 JSON 패턴 찾기
-        # content, focusing, keywords, lang 키를 가진 JSON 찾기
         data_pattern = r'\{[^{}]*"content"\s*:[^{}]*"focusing"\s*:[^{}]*\}'
         data_match = re.search(data_pattern, text, re.DOTALL)
         if data_match:
@@ -80,7 +76,6 @@ class LangChainModel:
             except json.JSONDecodeError:
                 pass
 
-        # 마지막 시도: trailing comma 수정
         try:
             fixed = re.sub(r',\s*}', '}', json_str)
             fixed = re.sub(r',\s*]', ']', fixed)
@@ -138,7 +133,6 @@ class LangChainModel:
 
         chain = self.prompt_generator.prompt | self.model | self._safe_parser()
 
-        print("[INFO] Trying OpenAI chain...")
         result = await self._invoke_with_retry(chain, input_data)
 
         if result:

--- a/src/llm_pipeline/schemas.py
+++ b/src/llm_pipeline/schemas.py
@@ -21,10 +21,15 @@ class Category(Enum):
 
 class TopicClassification(BaseModel):
     focusing: Category = Field(description="One of the predefined categories.")
+    # NB: min_items=1 (not 3) is intentional — small LLMs sometimes return
+    # an empty or 1-2 item list. The `pad_keywords` validator backfills
+    # "N/A" up to 3 so downstream storage and the article schema stay
+    # consistent. This replaces the previous behaviour of hard-failing
+    # validation and leaving the row stuck in article_queue forever.
     keywords: List[str] = Field(
-        min_items=3,
+        min_items=1,
         max_items=3,
-        description="Exactly 3 keywords."
+        description="Up to 3 keywords. Fewer values are backfilled with 'N/A'.",
     )
     quality_score: int = Field(
         ge=1,
@@ -34,6 +39,31 @@ class TopicClassification(BaseModel):
             "Articles scoring below the rejection threshold are moved to article_rejected."
         ),
     )
+
+    @validator('keywords', pre=True)
+    def pad_keywords(cls, v):
+        """Normalize keyword list: drop empties, dedupe, pad to exactly 3."""
+        if v is None:
+            return ["N/A", "N/A", "N/A"]
+        if isinstance(v, str):
+            v = [v]
+        if not isinstance(v, list):
+            return ["N/A", "N/A", "N/A"]
+        cleaned = []
+        seen = set()
+        for item in v:
+            if not isinstance(item, str):
+                continue
+            stripped = item.strip()
+            if not stripped or stripped in seen:
+                continue
+            seen.add(stripped)
+            cleaned.append(stripped)
+            if len(cleaned) == 3:
+                break
+        while len(cleaned) < 3:
+            cleaned.append("N/A")
+        return cleaned
 
     @validator('focusing', pre=True)
     def map_string_to_enum(cls, v):

--- a/src/main.py
+++ b/src/main.py
@@ -161,8 +161,18 @@ async def process_article(data):
             predict = await MODEL.predict(llm_query, False, False)
 
         if predict is None:
-            # Transient LLM failure — keep in queue for retry.
-            return None
+            # LLM returned unparseable output after 3 internal retries.
+            # This used to leave the row in article_queue for retry, but in
+            # practice identical inputs produce identical failures and the
+            # row got stuck forever. Route to article_rejected so the queue
+            # stays healthy; operators can recover via cmd/refetch_rejected
+            # if the model is later improved.
+            print(f"[REJECT] {article_id} — LLM extraction failed (None after retries)")
+            return _build_rejection(
+                data,
+                reason="llm_extraction_failed",
+                quality_score=1,
+            )
 
         # --- Post-LLM gate: quality score below threshold → reject terminally. ---
         if predict.quality_score < QUALITY_REJECT_THRESHOLD:

--- a/start-vllm.sh
+++ b/start-vllm.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# vLLM 서버 시작 스크립트
+# Ollama에서 다운로드한 GGUF 모델을 직접 사용
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/.venv/bin/activate"
+
+GGUF_PATH="$SCRIPT_DIR/qwen3.5-9b.gguf"
+
+echo "[vLLM] Starting server..."
+echo "[vLLM] Model: qwen3.5:9b (GGUF Q4_K_M)"
+echo "[vLLM] Max model len: 32768"
+echo "[vLLM] GPU memory utilization: 0.55"
+
+python3 -m vllm.entrypoints.openai.api_server \
+    --model "$GGUF_PATH" \
+    --tokenizer "Qwen/Qwen3.5-9B-Instruct" \
+    --served-model-name "qwen3.5:9b" \
+    --max-model-len 32768 \
+    --gpu-memory-utilization 0.55 \
+    --dtype half \
+    --port 8000 \
+    --host 0.0.0.0


### PR DESCRIPTION
## Summary
- **vLLM 단일화**: embedder도 Ollama에서 vLLM으로 이전, 두 vLLM 인스턴스(chat + embed)가 하나의 GPU에서 memory split으로 공존
- **self-hosted GPU 도커 스택**: AWS Lambda 완전 탈피, docker-compose.gpu.yml로 vLLM·embedder·harvest-post 전부 컨테이너화
- **단순화된 run.sh**: git pull → docker compose up --build → 큐 드레인 → sync → down → shutdown 플로우
- **LLM pipeline hardening**: keywords validation 완화 + 추출 실패 시 article_rejected 라우팅 (더 이상 queue stuck 없음)
- **CI/CD**: deploy-webhook 기반 GPU 배포, harvester-go와 동일 패턴

## Commits
- `f7b21b4` feat: vLLM 단일화 — Ollama 제거, embedder도 vLLM 사용
- `9046601` feat: self-hosted GPU Docker 스택 + 단순화된 run.sh
- `b656981` fix: LLM 키워드 검증 완화 + 추출 실패 시 rejected로 라우트
- `1c32e56` ci: GitHub Actions CI + deploy-webhook 기반 GPU 배포
- `bcbf9d5` ci: install pyyaml before running yaml validation step
- `be8cd59` ci: stub .env before docker compose config validation

## Verification
- [x] CI validates Python syntax, prompt.yml, docker-compose.gpu.yml
- [x] Build harvest_post image locally OK
- [ ] deploy-webhook updated on Mac infra (this PR's companion in infra repo)
- [ ] GPU one-time migration (wake, backup, rm+git clone, restore .env)
- [ ] End-to-end: push → CI → webhook → wake GPU → git pull → docker build → processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)