### PR TITLE
fix(pipeline): correct column order in article INSERT values

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -201,9 +201,9 @@ async def process_article(data):
             final_content,
             len(final_content),
             lang,
-            published_at,
             created_at,
             updated_at,
+            published_at,
         )
 
         return values, article_id


### PR DESCRIPTION
## Problem
`values` tuple in `process_article` passes `(published_at, created_at, updated_at)` but `COLUMN_NAMES` expects `(created_at, updated_at, published_at)`. Result: DB `published_at` gets the queue's `updated_at` (processing time), not the actual publication date. This caused the feed to sort by LLM batch processing order.

## Fix
One-line swap: `(created_at, updated_at, published_at)` to match `COLUMN_NAMES`.

## Impact
- New articles processed after this deploy will have correct `published_at`
- Existing data was already backfilled via a separate script (3129/3939 articles updated)